### PR TITLE
fixed resetting of MessageEventDefinition.messageRef, which caused th…

### DIFF
--- a/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/MessageConverterTest.java
+++ b/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/MessageConverterTest.java
@@ -2,9 +2,13 @@ package org.activiti.editor.language.xml;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.FlowElement;
 import org.activiti.bpmn.model.Message;
+import org.activiti.bpmn.model.MessageEventDefinition;
+import org.activiti.bpmn.model.StartEvent;
 import org.junit.Test;
 
 public class MessageConverterTest extends AbstractConverterTest {
@@ -28,6 +32,18 @@ public class MessageConverterTest extends AbstractConverterTest {
     assertEquals("Examples:writeReportItem", message.getItemRef());
     assertEquals("newWriteReport", message.getName());
     assertEquals("writeReport", message.getId());
+    
+    FlowElement flowElement = model.getFlowElement("theStart");
+    if(flowElement instanceof StartEvent){
+      StartEvent startEvent = (StartEvent) flowElement;
+      if(startEvent.getEventDefinitions().get(0) instanceof MessageEventDefinition){
+        MessageEventDefinition messageEventDefinition = (MessageEventDefinition) startEvent.getEventDefinitions().get(0);
+        assertNotNull("Attribute messageRef of messageEventDefinition can't be null.", messageEventDefinition.getMessageRef());
+        if(!(message.getId().equals(message.getName())) && messageEventDefinition.getMessageRef() != null){
+          assertTrue("MessageRef in messageEventDefinition of start event should be equal to messageId.", messageEventDefinition.getMessageRef().equals(message.getId()));
+        }
+      }
+    }
 
     Message message2 = model.getMessage("writeReport2");
     assertNotNull(message2);

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/EventSubscriptionManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/EventSubscriptionManager.java
@@ -84,14 +84,15 @@ public class EventSubscriptionManager {
 
   protected void insertMessageEvent(MessageEventDefinition messageEventDefinition, StartEvent startEvent, ProcessDefinitionEntity processDefinition, BpmnModel bpmnModel) {
     CommandContext commandContext = Context.getCommandContext();
+    Message message = null;
     if (bpmnModel.containsMessageId(messageEventDefinition.getMessageRef())) {
-      Message message = bpmnModel.getMessage(messageEventDefinition.getMessageRef());
-      messageEventDefinition.setMessageRef(message.getName());
+      message = bpmnModel.getMessage(messageEventDefinition.getMessageRef());
+      //messageEventDefinition.setMessageRef(message.getName());
     }
 
     // look for subscriptions for the same name in db:
     List<EventSubscriptionEntity> subscriptionsForSameMessageName = commandContext.getEventSubscriptionEntityManager()
-        .findEventSubscriptionsByName(MessageEventHandler.EVENT_HANDLER_TYPE, messageEventDefinition.getMessageRef(), processDefinition.getTenantId());
+        .findEventSubscriptionsByName(MessageEventHandler.EVENT_HANDLER_TYPE, message.getName(), processDefinition.getTenantId());
 
 
     for (EventSubscriptionEntity eventSubscriptionEntity : subscriptionsForSameMessageName) {
@@ -104,7 +105,7 @@ public class EventSubscriptionManager {
     }
 
     MessageEventSubscriptionEntity newSubscription = commandContext.getEventSubscriptionEntityManager().createMessageEventSubscription();
-    newSubscription.setEventName(messageEventDefinition.getMessageRef());
+    newSubscription.setEventName(message.getName());
     newSubscription.setActivityId(startEvent.getId());
     newSubscription.setConfiguration(processDefinition.getId());
     newSubscription.setProcessDefinitionId(processDefinition.getId());


### PR DESCRIPTION
…e test cases to pass but in actual testing message start event failed. Also modified the MessageConverterTest to check the messageEventDefinition.